### PR TITLE
fix: handle overnight work hours

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -179,7 +179,9 @@ function allowedNow() {
   const [eh, em] = (prefs.workEnd || '17:00').split(':').map(Number);
   const start = new Date(now); start.setHours(sh, sm || 0, 0, 0);
   const end   = new Date(now); end.setHours(eh, em || 0, 0, 0);
-  return now >= start && now <= end;
+
+  if (start <= end) return now >= start && now <= end;
+  return now >= start || now <= end;
 }
 
 function tryFire(kind, now, force = false) {


### PR DESCRIPTION
## Summary
- handle work-hour ranges that cross midnight so notifications still fire overnight

## Testing
- `node - <<'NODE'
const prefs = { weekdaysOnly: false, workHoursOnly: true, workStart: '22:00', workEnd: '06:00' };
function allowedNowTest(now) {
  if (prefs.weekdaysOnly) { const d = now.getDay(); if (d === 0 || d === 6) return false; }
  if (!prefs.workHoursOnly) return true;
  const [sh, sm] = (prefs.workStart || '09:00').split(':').map(Number);
  const [eh, em] = (prefs.workEnd || '17:00').split(':').map(Number);
  const start = new Date(now); start.setHours(sh, sm || 0, 0, 0);
  const end   = new Date(now); end.setHours(eh, em || 0, 0, 0);
  if (start <= end) return now >= start && now <= end;
  return now >= start || now <= end;
}
console.log('23:00 ->', allowedNowTest(new Date('2024-05-21T23:00:00')));
console.log('04:00 ->', allowedNowTest(new Date('2024-05-21T04:00:00')));
console.log('12:00 ->', allowedNowTest(new Date('2024-05-21T12:00:00')));
NODE`
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_b_689bd477f4b4832cbd1327b21cf851d9